### PR TITLE
Issue #8: Event datetimes are incorrect 

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,11 +40,12 @@ def main(csv_file: str, json_dir: str):
                     first_pass.append(cps.combine_record(
                         headers, row))
                 else:
-                    assert i > 0, "First row does not start with 'Id' or a digit. It is: {}".format(row[0])
-                
+                    assert i > 0, "First row does not start with 'Id' or a digit. It is: {}".format(
+                        row[0])
+
                 i = i + 1
 
-        # Now that we have a dictionary of headers and values, let's identify each part and 
+        # Now that we have a dictionary of headers and values, let's identify each part and
         # convert it into something much more useable.
         # Process each record in the dictionary and write it into a JSON file every time the
         # month changes.
@@ -68,7 +69,8 @@ def main(csv_file: str, json_dir: str):
                         with open(filename, 'w', encoding='utf-8') as jsonf:
                             jsonf.write(result)
                     except IOError as io:
-                        logger.exception("Problem writing to JSON file: {}. {}".format(filename, io))
+                        logger.exception(
+                            "Problem writing to JSON file: {}. {}".format(filename, io))
 
                     json_array = []
 
@@ -81,13 +83,14 @@ def main(csv_file: str, json_dir: str):
                     suffix = 'done'
 
     except FileNotFoundError as fnf:
-        logger.exception("Problem opening CSV file: {}. {}".format(csv_file, fnf))
+        logger.exception(
+            "Problem opening CSV file: {}. {}".format(csv_file, fnf))
 
 
 if __name__ == "__main__":
     """Passes the location and filename of the CSV file, as well as the directory
     to store the JSON files produced to the main function.
-    """    
+    """
     csv_file = r'sleep-as-android/csv/sleep-export-user.csv'
     json_directory = r'sleep-as-android/json'
 

--- a/main.py
+++ b/main.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     """Passes the location and filename of the CSV file, as well as the directory
     to store the JSON files produced to the main function.
     """    
-    csv_file = r'sleep-as-android/csv/sleep-export.csv'
+    csv_file = r'sleep-as-android/csv/sleep-export-user.csv'
     json_directory = r'sleep-as-android/json'
 
     main(csv_file, json_directory)

--- a/main.py
+++ b/main.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
     """Passes the location and filename of the CSV file, as well as the directory
     to store the JSON files produced to the main function.
     """
-    csv_file = r'sleep-as-android/csv/sleep-export-user.csv'
+    csv_file = r'sleep-as-android/csv/sleep-export.csv'
     json_directory = r'sleep-as-android/json'
 
     main(csv_file, json_directory)

--- a/utils/csv_parser.py
+++ b/utils/csv_parser.py
@@ -145,6 +145,10 @@ def follow_instructions(header: str, value: str, field_details: dict) -> tuple:
     if d_type == 'pk':
         pk_value = df.process_pk(value)
         field = (field_name, pk_value)
+    
+    elif d_type == 'tz':
+        tz_value = df.process_tz(value)
+        field = (field_name, tz_value)
 
     elif d_type == 'datetime':
         dt_value = df.process_dates(value)

--- a/utils/csv_parser.py
+++ b/utils/csv_parser.py
@@ -145,7 +145,7 @@ def follow_instructions(header: str, value: str, field_details: dict) -> tuple:
     if d_type == 'pk':
         pk_value = df.process_pk(value)
         field = (field_name, pk_value)
-    
+
     elif d_type == 'tz':
         tz_value = df.process_tz(value)
         field = (field_name, tz_value)

--- a/utils/data_functions.py
+++ b/utils/data_functions.py
@@ -182,8 +182,9 @@ def process_event(event: str) -> dict:
 
     event_type = event_parts[0]
 
-    timestamp = datetime.fromtimestamp(int(event_parts[1])/1000, ZoneInfo(str(globals.time_zone)))
-    # We want the event time in milliseconds, because the DHA event occurs every 1 
+    timestamp = datetime.fromtimestamp(
+        int(event_parts[1])/1000, ZoneInfo(str(globals.time_zone)))
+    # We want the event time in milliseconds, because the DHA event occurs every 1
     # millisecond until you fall asleep.
     event_time = timestamp.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
 

--- a/utils/data_functions.py
+++ b/utils/data_functions.py
@@ -1,8 +1,16 @@
 import json
+from zoneinfo import ZoneInfo
 from datetime import datetime, timedelta
 from utils import globals
 
 globals.init()
+
+
+def set_start_time():
+    starting = int(globals.pk)
+    time_zone = str(globals.time_zone)
+    datetime_value = datetime.fromtimestamp(starting/1000, ZoneInfo(time_zone))
+    globals.start_time = datetime_value
 
 
 def process_suffix(pk) -> str:
@@ -38,12 +46,18 @@ def process_pk(key: str) -> int:
     int
         Original Unix timestamp in integer form.
     """
-    datetime_value = datetime.fromtimestamp(int(key)/1000)
-
-    globals.start_time = datetime_value
+    globals.pk = key
 
     value = process_integer(key)
     return value
+
+
+def process_tz(tz: str) -> str:
+    globals.time_zone = tz
+
+    set_start_time()
+
+    return tz
 
 
 def process_dates(detail: str) -> str:
@@ -168,7 +182,7 @@ def process_event(event: str) -> dict:
 
     event_type = event_parts[0]
 
-    timestamp = datetime.fromtimestamp(int(event_parts[1])/1000)
+    timestamp = datetime.fromtimestamp(int(event_parts[1])/1000, ZoneInfo(str(globals.time_zone)))
     # We want the event time in milliseconds, because the DHA event occurs every 1 
     # millisecond until you fall asleep.
     event_time = timestamp.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]

--- a/utils/data_functions.py
+++ b/utils/data_functions.py
@@ -7,9 +7,16 @@ globals.init()
 
 
 def set_start_time():
+    """Using the global variables 'pk' (Unix timestamp) and 'time_zone' from
+    the Sleep as Android file, sets the start time of the sleep session.
+
+    This is used for actigraphy and events.
+    """
     starting = int(globals.pk)
     time_zone = str(globals.time_zone)
+
     datetime_value = datetime.fromtimestamp(starting/1000, ZoneInfo(time_zone))
+
     globals.start_time = datetime_value
 
 
@@ -33,7 +40,7 @@ def process_suffix(pk) -> str:
 
 def process_pk(key: str) -> int:
     """Handles the primary key from Sleep as Android, which is the session
-    start Unix timestamp. It is assigned to the global variable 'start_time'
+    start Unix timestamp. It is assigned to the global variable 'pk'
     and then transformed for primary key purposes.
 
     Parameters
@@ -53,6 +60,20 @@ def process_pk(key: str) -> int:
 
 
 def process_tz(tz: str) -> str:
+    """Handles the time zone from Sleep as Android, assigning it to a global
+    variable 'time_zone' which is later used to correctly transform the Unix
+    timestamps for the session start and events.
+
+    Parameters
+    ----------
+    tz : str
+        The time zone string, e.g. 'Australia/Perth'
+
+    Returns
+    -------
+    str
+        The same time zone string.
+    """
     globals.time_zone = tz
 
     set_start_time()

--- a/utils/globals.py
+++ b/utils/globals.py
@@ -3,13 +3,25 @@ from datetime import datetime
 
 def init():
     """Contains global variables.
-    """    
+    """   
+    global pk 
     global start_time
+    global time_zone
     global saa_fields
+
+    # This is the primary key of a sleep record from Sleep as
+    # Android, which is a Unix timestamp. It is set at the 
+    # beginning of each new sleep record.
+    pk = int
 
     # This is the start datetime of the sleep session which is set
     # at the beginning of each new sleep record.
     start_time = datetime
+
+    # This is a text representation of the time zone recorded by
+    # Sleep as Android and is set at the beginning of each new sleep
+    # record.
+    time_zone = str
 
     # These are the fields we've identified in the Sleep as Android
     # output, and this dictionary details how we handle each one.
@@ -20,7 +32,7 @@ def init():
         },
         'Tz': {
             'name': 'timezone',
-            'type': 'string'
+            'type': 'tz'
         },
         'From': {
             'name': 'tracking_start',

--- a/utils/globals.py
+++ b/utils/globals.py
@@ -3,14 +3,14 @@ from datetime import datetime
 
 def init():
     """Contains global variables.
-    """   
-    global pk 
+    """
+    global pk
     global start_time
     global time_zone
     global saa_fields
 
     # This is the primary key of a sleep record from Sleep as
-    # Android, which is a Unix timestamp. It is set at the 
+    # Android, which is a Unix timestamp. It is set at the
     # beginning of each new sleep record.
     pk = int
 


### PR DESCRIPTION
Resolves issue #8 by including the time zone provided by the Sleep as Android CSV file when converting event Unix timestamps into datetime strings.